### PR TITLE
Update ApnChannel.php

### DIFF
--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -58,10 +58,6 @@ class ApnChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $this->openConnection()) {
-            return;
-        }
-
         $tokens = (array) $notifiable->routeNotificationFor('apn');
         if (! $tokens) {
             return;
@@ -69,6 +65,10 @@ class ApnChannel
 
         $message = $notification->toApn($notifiable);
         if (! $message) {
+            return;
+        }
+        
+        if (! $this->openConnection()) {
             return;
         }
 


### PR DESCRIPTION
In case there are no tokens or no messages the connection is opened and stays opened. This fix prevents what happened in issue #10 and it opens the connection only if there are tokens or messages to send.