### PR TITLE
Fix name of method in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ class AccountApproved extends Notification
         return [ApnChannel::class];
     }
 
-    public function toApnNotification($notifiable)
+    public function toApn($notifiable)
     {
         return ApnMessage::create()
             ->badge(1)


### PR DESCRIPTION
The actual method for formatting the ApnMessage is toApn(). In the README, it is listed as toApnNotification(). This simply corrects the method name to help avoid confusion for new users of the package.