### PR TITLE
batch send failure #31

### DIFF
--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -107,6 +107,10 @@ class ApnChannel
                             'error' => $response->getCode(),
                         ])
                     );
+                    
+                    //connection is useless so create a new connection
+                    $this->closeConnection();
+                    $this->openConnection();
                 }
             } catch (Exception $e) {
                 throw SendingFailed::create($e);

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -107,7 +107,6 @@ class ApnChannel
                             'error' => $response->getCode(),
                         ])
                     );
-                    
                     //connection is useless so create a new connection
                     $this->closeConnection();
                     $this->openConnection();

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -2,14 +2,14 @@
 
 namespace NotificationChannels\Gcm\Test;
 
+use Mockery;
+use PHPUnit_Framework_TestCase;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Notifications\Notifiable;
 use NotificationChannels\Apn\ApnChannel;
-use Illuminate\Notifications\Notification;
-use NotificationChannels\Apn\ApnFeedback;
 use NotificationChannels\Apn\ApnMessage;
-use PHPUnit_Framework_TestCase;
-use Mockery;
+use NotificationChannels\Apn\ApnFeedback;
+use Illuminate\Notifications\Notification;
 use ZendService\Apple\Apns\Client\Message as Client;
 use ZendService\Apple\Apns\Client\Feedback as FeedbackClient;
 use ZendService\Apple\Apns\Response\Message as MessageResponse;


### PR DESCRIPTION
create a nwe connection if sending a message failed because apple ignores rest of tokens on that connection