### PR TITLE
Add support for Laravel autodiscovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "NotificationChannels\\Apn\\Test\\": "tests"
+            "NotificationChannels\\Apn\\Tests\\": "tests"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,11 @@
     "extra": {
         "branch-alias": {
             "dev-master": "0.2-dev"
+        },
+        "laravel": {
+            "providers": [
+                "NotificationChannels\\Apn\\ApnServiceProvider"
+            ]
         }
     }
 }

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace NotificationChannels\Gcm\Test;
+namespace NotificationChannels\Apn\Tests;
 
+use Mockery;
+use PHPUnit_Framework_TestCase;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Notifications\Notifiable;
 use NotificationChannels\Apn\ApnChannel;
-use Illuminate\Notifications\Notification;
-use NotificationChannels\Apn\ApnFeedback;
 use NotificationChannels\Apn\ApnMessage;
-use PHPUnit_Framework_TestCase;
-use Mockery;
+use NotificationChannels\Apn\ApnFeedback;
+use Illuminate\Notifications\Notification;
 use ZendService\Apple\Apns\Client\Message as Client;
 use ZendService\Apple\Apns\Client\Feedback as FeedbackClient;
 use ZendService\Apple\Apns\Response\Message as MessageResponse;


### PR DESCRIPTION
This simply allows the service provider to be auto-discovered by Laravel, saving a configuration step when installing the package.

Edit: also fixed a couple of issues with StyleCI - ordering of imports and fixing the namespacing.