### PR TITLE
One connection needs to be opened for each token

### DIFF
--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -71,14 +71,14 @@ class ApnChannel
             return;
         }
 
-        $this->openConnection();
-
         foreach ($tokens as $token) {
+            if (! $this->openConnection()) {
+                continue;
+            }
             $packet = $this->getPacket($message, $token);
             $this->sendPacket($notifiable, $notification, $packet, $token);
+            $this->closeConnection();
         }
-
-        $this->closeConnection();
     }
 
     /**

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -72,9 +72,7 @@ class ApnChannel
         }
 
         foreach ($tokens as $token) {
-            if (! $this->openConnection()) {
-                continue;
-            }
+            $this->openConnection();
             $packet = $this->getPacket($message, $token);
             $this->sendPacket($notifiable, $notification, $packet, $token);
             $this->closeConnection();

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -63,9 +63,9 @@ class ChannelTest extends TestCase
         $responseFail->setCode(MessageResponse::RESULT_INVALID_TOKEN);
 
         $this->events->shouldReceive('fire')->twice();
-        $this->client->shouldReceive('open')->once();
+        $this->client->shouldReceive('open')->twice();
         $this->client->shouldReceive('send')->twice()->andReturn($responseFail);
-        $this->client->shouldReceive('close')->once();
+        $this->client->shouldReceive('close')->twice();
 
         $this->channel->send($this->notifiable, $this->notification);
     }

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -47,9 +47,9 @@ class ChannelTest extends TestCase
         $responseOk->setCode(MessageResponse::RESULT_OK);
 
         $this->events->shouldNotReceive('fire');
-        $this->client->shouldReceive('open')->once();
+        $this->client->shouldReceive('open')->twice();
         $this->client->shouldReceive('send')->twice()->andReturn($responseOk);
-        $this->client->shouldReceive('close')->once();
+        $this->client->shouldReceive('close')->twice();
 
         $this->channel->send($this->notifiable, $this->notification);
     }


### PR DESCRIPTION
I found out that only one notification can be send to each open connection. In order to avoid this problem I open a connection on every token.

It might be better to automatically open connections as suggested in:
https://github.com/laravel-notification-channels/apn/pull/37

How ever this is simpler and does the trick.