### PR TITLE
Break ApnMessage to Zend Message out of channel

### DIFF
--- a/src/ApnAdapter.php
+++ b/src/ApnAdapter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace NotificationChannels\Apn;
+
+use ZendService\Apple\Apns\Message;
+use ZendService\Apple\Apns\Message\Alert;
+
+class ApnAdapter
+{
+    /**
+     * Convert an ApnMessage instance into a Zend Apns Message.
+     *
+     * @param  \NotificationChannels\Apn\ApnMessage  $message
+     * @param  string  $token
+     * @return \ZendService\Apple\Apns\Message
+     */
+    public function adapt(ApnMessage $message, $token)
+    {
+        $alert = new Alert();
+        $alert->setTitle($message->title);
+        $alert->setBody($message->body);
+
+        $packet = new Message;
+        $packet->setToken($token);
+        $packet->setBadge($message->badge);
+        $packet->setSound($message->sound);
+        $packet->setCategory($message->category);
+        $packet->setContentAvailable($message->contentAvailable);
+        $packet->setAlert($alert);
+        $packet->setCustom($message->custom);
+
+        return $packet;
+    }
+}

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -4,7 +4,9 @@ namespace NotificationChannels\Apn\Tests;
 
 use Mockery;
 use Illuminate\Events\Dispatcher;
+use ZendService\Apple\Apns\Message;
 use Illuminate\Notifications\Notifiable;
+use NotificationChannels\Apn\ApnAdapter;
 use NotificationChannels\Apn\ApnChannel;
 use NotificationChannels\Apn\ApnMessage;
 use Illuminate\Notifications\Notification;
@@ -29,8 +31,9 @@ class ChannelTest extends TestCase
     {
         $this->client = Mockery::mock(Client::class);
         $this->events = Mockery::mock(Dispatcher::class);
+        $this->adapter = Mockery::mock(ApnAdapter::class);
         $this->credentials = $this->getTestCredentials();
-        $this->channel = new ApnChannel($this->client, $this->events, $this->credentials);
+        $this->channel = new ApnChannel($this->client, $this->events, $this->adapter, $this->credentials);
         $this->notification = new TestNotification;
         $this->notifiable = new TestNotifiable;
     }
@@ -43,6 +46,7 @@ class ChannelTest extends TestCase
         $responseOk = new MessageResponse();
         $responseOk->setCode(MessageResponse::RESULT_OK);
 
+        $this->adapter->shouldReceive('adapt')->andReturn(new Message);
         $this->events->shouldNotReceive('fire');
         $this->client->shouldReceive('open')->twice();
         $this->client->shouldReceive('send')->twice()->andReturn($responseOk);
@@ -59,6 +63,7 @@ class ChannelTest extends TestCase
         $responseFail = new MessageResponse();
         $responseFail->setCode(MessageResponse::RESULT_INVALID_TOKEN);
 
+        $this->adapter->shouldReceive('adapt')->andReturn(new Message);
         $this->events->shouldReceive('fire')->twice();
         $this->client->shouldReceive('open')->twice();
         $this->client->shouldReceive('send')->twice()->andReturn($responseFail);


### PR DESCRIPTION
This breaks the logic for converting our home grown `ApnMessage` into the `ZendService\Apple\Apns\Message` instance required to fire it down through their client. It's not the concern of the channel class to know how to adapt between the two formats.