### PR TITLE
Allow notification routing to depend on notification being sent

### DIFF
--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -64,7 +64,7 @@ class ApnChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        $tokens = (array) $notifiable->routeNotificationFor('apn');
+        $tokens = (array) $notifiable->routeNotificationFor('apn', $notification);
         if (empty($tokens)) {
             return;
         }


### PR DESCRIPTION
This adds support for the feature added in Laravel 5.6 for routing based on the notification being sent.
[The merged PR is here](https://github.com/laravel/framework/pull/22289)