### PR TITLE
Changed fire method to dispatch to support Laravel 5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/apn/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/apn/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/apn.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/apn)
 
-This package makes it easy to send notifications using Apple Push (APN) with Laravel 5.3.
+This package makes it easy to send notifications using Apple Push (APN) with Laravel 5.8.
 
 ## Contents
 

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -115,7 +115,7 @@ class ApnChannel
             $response = $this->client->send($message);
 
             if ($response->getCode() !== Response::RESULT_OK) {
-                $this->events->fire(
+                $this->events->dispatch(
                     new NotificationFailed($notifiable, $notification, $this, [
                         'token' => $token,
                         'error' => $response->getCode(),

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -47,7 +47,7 @@ class ChannelTest extends TestCase
         $responseOk->setCode(MessageResponse::RESULT_OK);
 
         $this->adapter->shouldReceive('adapt')->andReturn(new Message);
-        $this->events->shouldNotReceive('fire');
+        $this->events->shouldNotReceive('dispatch');
         $this->client->shouldReceive('open')->twice();
         $this->client->shouldReceive('send')->twice()->andReturn($responseOk);
         $this->client->shouldReceive('close')->twice();
@@ -64,7 +64,7 @@ class ChannelTest extends TestCase
         $responseFail->setCode(MessageResponse::RESULT_INVALID_TOKEN);
 
         $this->adapter->shouldReceive('adapt')->andReturn(new Message);
-        $this->events->shouldReceive('fire')->twice();
+        $this->events->shouldReceive('dispatch')->twice();
         $this->client->shouldReceive('open')->twice();
         $this->client->shouldReceive('send')->twice()->andReturn($responseFail);
         $this->client->shouldReceive('close')->twice();


### PR DESCRIPTION
This package doesn't currently work in Laravel 5.8 due to the removal of the `fire` method on the `Illuminate\Events\Dispatcher` class. The solution is to replace the `fire` method with `dispatch`.

Reference: [Laravel 5.8 Upgrade Guide](https://laravel.com/docs/5.8/upgrade)