### PR TITLE
Expose the notification responses from pushok's library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ public function routeNotificationForApn()
  - `badge($integer)`
  - `custom($customData)`
 
-
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/README.md
+++ b/README.md
@@ -78,15 +78,6 @@ class AccountApproved extends Notification
 }
 ```
 
-In your `notifiable` model, make sure to include a `routeNotificationForApn()` method, which return one or an array of tokens.
-
-```php
-public function routeNotificationForApn()
-{
-    return $this->apn_token;
-}
-```
-
 ### Available methods
 
  - `title($str)`

--- a/README.md
+++ b/README.md
@@ -78,23 +78,21 @@ class AccountApproved extends Notification
 }
 ```
 
+In your `notifiable` model, make sure to include a `routeNotificationForApn()` method, which return one or an array of tokens.
+
+```php
+public function routeNotificationForApn()
+{
+    return $this->apn_token;
+}
+```
+
 ### Available methods
 
  - `title($str)`
  - `body($str)`
  - `badge($integer)`
  - `custom($customData)`
-
-## Capture Responses
-
-In your `notifiable` model, make sure to include a `storeResponses($responses)` method which will store the responses in the notifiable model.
-
-```php
-public function storeResponses($responses)
-{
-    return $this->responses;
-}
-```
 
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ public function routeNotificationForApn()
  - `badge($integer)`
  - `custom($customData)`
 
+## Capture Responses
+```
+
+In your `notifiable` model, make sure to include a `storeResponses($responses)` method which will store the responses in the notifiable model.
+
+```php
+public function storeResponses($responses)
+{
+    return $this->responses;
+}
+```
+
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ public function routeNotificationForApn()
  - `custom($customData)`
 
 ## Capture Responses
-```
 
 In your `notifiable` model, make sure to include a `storeResponses($responses)` method which will store the responses in the notifiable model.
 

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -30,12 +30,6 @@ class ApnChannel
     protected $client;
 
     /**
-     * The responses from each notification sent.
-     * @var array
-     */
-    private $responses;
-
-    /**
      * Create a new channel instance.
      *
      * @param  \Pushok\Client  $client
@@ -63,7 +57,8 @@ class ApnChannel
 
         $payload = (new ApnAdapter)->adapt($message);
 
-        $this->sendNotifications($tokens, $payload);
+        $responses = $this->sendNotifications($tokens, $payload);
+        $this->storeResponses($notifiable, $responses);
     }
 
     /**
@@ -91,6 +86,20 @@ class ApnChannel
 
         $this->client->addNotifications($notifications);
 
-        $this->responses = $this->client->push();
+        return $this->client->push();
+    }
+
+    /**
+     * Store the responses from sending the push notification into the notifiable.
+     *
+     * @param $notifiable
+     * @param $responses
+     */
+    private function storeResponses($notifiable, $responses)
+    {
+        if (method_exists($notifiable, 'storeResponses'))
+        {
+            $notifiable->storeResponses($responses);
+        }
     }
 }

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -62,15 +62,6 @@ class ApnChannel
     }
 
     /**
-     * Returns an array of ApnsResponseInterfaces from the most recent sending of push notifications.
-     * @return array
-     */
-    public function retrieveResponses()
-    {
-        return $this->responses;
-    }
-
-    /**
      * Send the notification to each of the provided tokens.
      *
      * @param  array  $tokens

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -30,6 +30,12 @@ class ApnChannel
     protected $client;
 
     /**
+     * The responses from the each notification sent.
+     * @var array
+     */
+    private $responses;
+
+    /**
      * Create a new channel instance.
      *
      * @param  \Pushok\Client  $client
@@ -61,6 +67,14 @@ class ApnChannel
     }
 
     /**
+     * Returns an array of ApnsResponseInterfaces from the most recent sending of push notifications.
+     * @return array
+     */
+    public function retrieveResponses(){
+        return $this->responses;
+    }
+
+    /**
      * Send the notification to each of the provided tokens.
      *
      * @param  array  $tokens
@@ -77,6 +91,6 @@ class ApnChannel
 
         $this->client->addNotifications($notifications);
 
-        $this->client->push();
+        $this->responses = $this->client->push();
     }
 }

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -65,7 +65,8 @@ class ApnChannel
      * Returns an array of ApnsResponseInterfaces from the most recent sending of push notifications.
      * @return array
      */
-    public function retrieveResponses(){
+    public function retrieveResponses()
+    {
         return $this->responses;
     }
 
@@ -97,8 +98,7 @@ class ApnChannel
      */
     private function storeResponses($notifiable, $responses)
     {
-        if (method_exists($notifiable, 'storeResponses'))
-        {
+        if (method_exists($notifiable, 'storeResponses')) {
             $notifiable->storeResponses($responses);
         }
     }

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -30,7 +30,7 @@ class ApnChannel
     protected $client;
 
     /**
-     * The responses from the each notification sent.
+     * The responses from each notification sent.
      * @var array
      */
     private $responses;

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -44,6 +44,7 @@ class ApnChannel
      *
      * @param mixed $notifiable
      * @param \Illuminate\Notifications\Notification $notification
+     * @return mixed|void
      */
     public function send($notifiable, Notification $notification)
     {
@@ -57,8 +58,7 @@ class ApnChannel
 
         $payload = (new ApnAdapter)->adapt($message);
 
-        $responses = $this->sendNotifications($tokens, $payload);
-        $this->storeResponses($notifiable, $responses);
+        return $this->sendNotifications($tokens, $payload);
     }
 
     /**
@@ -79,18 +79,5 @@ class ApnChannel
         $this->client->addNotifications($notifications);
 
         return $this->client->push();
-    }
-
-    /**
-     * Store the responses from sending the push notification into the notifiable.
-     *
-     * @param $notifiable
-     * @param $responses
-     */
-    private function storeResponses($notifiable, $responses)
-    {
-        if (method_exists($notifiable, 'storeResponses')) {
-            $notifiable->storeResponses($responses);
-        }
     }
 }


### PR DESCRIPTION
Allow a user to store the array of ApnsResponseInterface objects from the most recent sending of push notifications. If the method exists on the notifiable method we'll execute the storeResponses method. This allows a user to then capture the notification at the tail end of its execution path and potentially log those responses.

```
$responses = $client->push(); // returns an array of ApnsResponseInterface (one Response per Notification)

 foreach ($responses as $response) {
     $response->getApnsId();
     $response->getStatusCode();
     $response->getReasonPhrase();
     $response->getErrorReason();
     $response->getErrorDescription();
 }
```

https://github.com/edamov/pushok