### PR TITLE
Return the response object as an associative array for the NotificationSent event to serialize properly

### DIFF
--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -60,7 +60,8 @@ class ApnChannel
 
         $responseObjects = $this->sendNotifications($tokens, $payload);
         $responses = [];
-        foreach ($responseObjects as $response){
+        foreach ($responseObjects as $response)
+        {
             $responseValues[] = [
                 'token' => $response->getDeviceToken(),
                 'apnsId' => $response->getApnsId(),

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -58,7 +58,18 @@ class ApnChannel
 
         $payload = (new ApnAdapter)->adapt($message);
 
-        return $this->sendNotifications($tokens, $payload);
+        $responses = $this->sendNotifications($tokens, $payload);
+        $responseValues = [];
+        foreach ($responses as $response){
+            $responseValues[] = [
+                'token' => $response->getDeviceToken(),
+                'apnsId' => $response->getApnsId(),
+                'status' => $response->getStatusCode(),
+                'errorReason' => $response->getErrorReason(),
+                'errorDescription' => $response->getErrorDescription(),
+            ];
+        }
+        return $responseValues;
     }
 
     /**

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -62,7 +62,7 @@ class ApnChannel
         $responses = [];
         foreach ($responseObjects as $response)
         {
-            $responseValues[] = [
+            $responses[] = [
                 'token' => $response->getDeviceToken(),
                 'apnsId' => $response->getApnsId(),
                 'status' => $response->getStatusCode(),

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -58,9 +58,9 @@ class ApnChannel
 
         $payload = (new ApnAdapter)->adapt($message);
 
-        $responses = $this->sendNotifications($tokens, $payload);
-        $responseValues = [];
-        foreach ($responses as $response){
+        $responseObjects = $this->sendNotifications($tokens, $payload);
+        $responses = [];
+        foreach ($responseObjects as $response){
             $responseValues[] = [
                 'token' => $response->getDeviceToken(),
                 'apnsId' => $response->getApnsId(),
@@ -69,7 +69,7 @@ class ApnChannel
                 'errorDescription' => $response->getErrorDescription(),
             ];
         }
-        return $responseValues;
+        return $responses;
     }
 
     /**


### PR DESCRIPTION
When sending over an array of ApnsResponseInterface we receive an array of empty objects. I think this happens with how the NotificationSent event serializes the response object. To resolve this we need to call upon the getter commands of the implemented ApnsResponseInterface to access the implemented properties. I construct an associative array with the respective parameters. 

Before:
![image](https://user-images.githubusercontent.com/4874111/74886125-2acd8580-532c-11ea-8d7f-ce83a5fd39de.png)


After:
![image](https://user-images.githubusercontent.com/4874111/74886103-1db09680-532c-11ea-8e84-3ed6c0b288a1.png)
