### PR TITLE
Adjust adapter to support more options

### DIFF
--- a/src/ApnAdapter.php
+++ b/src/ApnAdapter.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\Apn;
 
+use Pushok\Notification;
 use Pushok\Payload;
 use Pushok\Payload\Alert;
 
@@ -11,9 +12,10 @@ class ApnAdapter
      * Convert an ApnMessage instance into a Zend Apns Message.
      *
      * @param  \NotificationChannels\Apn\ApnMessage  $message
-     * @return \Pushok\Payload
+     * @param  string  $token
+     * @return \Pushok\Notification
      */
-    public function adapt(ApnMessage $message)
+    public function adapt(ApnMessage $message, string $token)
     {
         $alert = Alert::create();
 
@@ -46,6 +48,12 @@ class ApnAdapter
             $payload->setCustomValue($key, $value);
         }
 
-        return $payload;
+        $notification = new Notification($payload, $token);
+
+        if ($expiresAt = $message->expiresAt) {
+            $notification->setExpirationAt($expiresAt);
+        }
+
+        return $notification;
     }
 }

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -4,7 +4,6 @@ namespace NotificationChannels\Apn;
 
 use Illuminate\Notifications\Notification;
 use Pushok\Client;
-use Pushok\Notification as PushNotification;
 
 class ApnChannel
 {
@@ -58,27 +57,9 @@ class ApnChannel
 
         $client = $message->client ?? $this->client;
 
-        $payload = (new ApnAdapter)->adapt($message);
-
-        return $this->sendNotifications($client, $tokens, $payload);
-    }
-
-    /**
-     * Send the notification to each of the provided tokens.
-     *
-     * @param  array  $tokens
-     * @param  \Pushok\Payload  $payload
-     * @return array
-     */
-    protected function sendNotifications($client, $tokens, $payload)
-    {
-        $notifications = [];
-
         foreach ($tokens as $token) {
-            $notifications[] = new PushNotification($payload, $token);
+            $client->addNotification((new ApnAdapter)->adapt($message, $token));
         }
-
-        $client->addNotifications($notifications);
 
         return $client->push();
     }

--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\Apn;
 
+use DateTime;
 use Pushok\Client;
 
 class ApnMessage
@@ -61,6 +62,13 @@ class ApnMessage
      * @var \string
      */
     public $pushType = null;
+
+    /**
+     * The expiration time of the notification.
+     *
+     * @var \DateTime|null
+     */
+    public $expiresAt = null;
 
     /**
      * Message specific client.
@@ -197,6 +205,20 @@ class ApnMessage
     public function pushType(string $pushType)
     {
         $this->pushType = $pushType;
+
+        return $this;
+    }
+
+    /**
+     * Set the expiration time for the message.
+     *
+     * @param  \DateTime  $expiresAt
+     *
+     * @return $this
+     */
+    public function expiresAt(DateTime $expiresAt)
+    {
+        $this->expiresAt = $expiresAt;
 
         return $this;
     }

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -28,7 +28,7 @@ class ChannelTest extends TestCase
     {
         $message = $this->notification->toApn($this->notifiable);
 
-        $this->client->shouldReceive('addNotifications');
+        $this->client->shouldReceive('addNotification');
         $this->client->shouldReceive('push')->once();
 
         $this->channel->send($this->notifiable, $this->notification);

--- a/tests/ApnMessageTest.php
+++ b/tests/ApnMessageTest.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\Apn\Tests;
 
+use DateTime;
 use Mockery;
 use NotificationChannels\Apn\ApnMessage;
 use Pushok\Client;
@@ -99,6 +100,19 @@ class ApnMessageTest extends TestCase
         $message->pushType('type');
 
         $this->assertEquals('type', $message->pushType);
+    }
+
+    /** @test */
+    public function it_can_set_expires_at()
+    {
+        $message = new ApnMessage;
+
+        $now = new DateTime;
+
+        $result = $message->expiresAt($now);
+
+        $this->assertEquals($now, $message->expiresAt);
+        $this->assertEquals($message, $result);
     }
 
     /** @test */


### PR DESCRIPTION
Right now the channel loops over instances of `Pushok\Payload` to wrap them up into a `Pushok\Notification` with a given token. This makes it difficult for the message to actually interact with the final notification abstraction - which is where the `expires` option is available.

This updates our adapter to completely wrap up the alert/payload/notification sequence giving the message maximum flexibility.

Closes #58