### PR TITLE
Dispatch NotificationFailed events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": "^7.2",
         "edamov/pushok": "^0.10.4",
         "illuminate/config": "^6.0",
+        "illuminate/events": "^6.0",
         "illuminate/notifications": "^6.0",
         "illuminate/support": "^6.0"
     },

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -2,8 +2,11 @@
 
 namespace NotificationChannels\Apn;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notification;
 use Pushok\Client;
+use Pushok\Response;
 
 class ApnChannel
 {
@@ -29,13 +32,22 @@ class ApnChannel
     protected $client;
 
     /**
+     * The event dispatcher.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher
+     */
+    protected $events;
+
+    /**
      * Create a new channel instance.
      *
      * @param  \Pushok\Client  $client
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      */
-    public function __construct(Client $client)
+    public function __construct(Client $client, Dispatcher $events)
     {
         $this->client = $client;
+        $this->events = $events;
     }
 
     /**
@@ -53,14 +65,54 @@ class ApnChannel
             return;
         }
 
-        $message = $notification->toApn($notifiable);
+        $responses = $this->sendNotifications(
+            $message->client ?? $this->client,
+            $notification->toApn($notifiable),
+            $tokens
+        );
 
-        $client = $message->client ?? $this->client;
+        $this->dispatchEvents($responses);
 
+        return $responses;
+    }
+
+    /**
+     * Send the message to the given tokens through the given client.
+     *
+     * @param  \Pushok\Client  $client
+     * @param  \NotificationChannels\Apn\ApnMessage  $message
+     * @param  array  $tokens
+     * @return array
+     */
+    protected function sendNotifications(Client $client, ApnMessage $message, array $tokens)
+    {
         foreach ($tokens as $token) {
             $client->addNotification((new ApnAdapter)->adapt($message, $token));
         }
 
         return $client->push();
+    }
+
+    /**
+     * Dispatch failed events for notifications that weren't delivered.
+     *
+     * @param  array  $responses
+     * @return void
+     */
+    protected function dispatchEvents(array $responses)
+    {
+        foreach ($responses as $response) {
+            if ($response->getStatusCode() === Response::APNS_SUCCESS) {
+                continue;
+            }
+
+            $event = new NotificationFailed($notifiable, $notification, $this, [
+                'id' => $response->getApnsId(),
+                'token' => $response->getDeviceToken(),
+                'error' => $response->getErrorReason(),
+            ]);
+
+            $this->events->dispatch($event);
+        }
     }
 }

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -71,7 +71,7 @@ class ApnChannel
             $tokens
         );
 
-        $this->dispatchEvents($responses);
+        $this->dispatchEvents($notifiable, $notification, $responses);
 
         return $responses;
     }
@@ -96,10 +96,12 @@ class ApnChannel
     /**
      * Dispatch failed events for notifications that weren't delivered.
      *
-     * @param  array  $responses
+     * @param mixed $notifiable
+     * @param \Illuminate\Notifications\Notification $notification
+     * @param array $responses
      * @return void
      */
-    protected function dispatchEvents(array $responses)
+    protected function dispatchEvents($notifiable, $notification, array $responses)
     {
         foreach ($responses as $response) {
             if ($response->getStatusCode() === Response::APNS_SUCCESS) {

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\Apn\Tests;
 
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Mockery;
@@ -12,13 +13,15 @@ use Pushok\Client;
 class ChannelTest extends TestCase
 {
     protected $client;
+    protected $events;
     protected $notification;
     protected $channel;
 
     public function setUp(): void
     {
         $this->client = Mockery::mock(Client::class);
-        $this->channel = new ApnChannel($this->client);
+        $this->events = Mockery::mock(Dispatcher::class);
+        $this->channel = new ApnChannel($this->client, $this->events);
         $this->notification = new TestNotification;
         $this->notifiable = new TestNotifiable;
     }

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -53,7 +53,7 @@ class ChannelTest extends TestCase
             ->once()
             ->andReturn([
                 new Response(200, 'headers', 'body'),
-                new Response(400, 'headers', 'body')
+                new Response(400, 'headers', 'body'),
             ]);
 
         $this->channel->send($this->notifiable, $this->notification);


### PR DESCRIPTION
Following some discussion around best practices here (https://github.com/laravel/framework/pull/14874) this PR introduces handling of failed notifications by dispatching Laravel's `NotificationFailed` event. 

Note that if there is a hard failure - an exception of some sort - that will still be thrown and reported through your logging provider. 

This provides a mechanism for your app to hook in to failed deliveries and handle them as necessary - for example, to remove old push tokens.