### PR TITLE
Rework production configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Collect your Key ID, as well as your Team ID (displayed at the top right of the 
     'connections' => [
 
       'apn' => [
+            'production' => true,
             'key_id' => env('APN_KEY_ID'),
             'team_id' => env('APN_TEAM_ID'),
             'app_bundle_id' => env('APN_BUNDLE_ID'),
             'private_key_content' => env('APN_PRIVATE_KEY'),
-            'environment' => \NotificationChannels\Apn\ApnChannel::PRODUCTION,
       ],
 
     ]

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Collect your Key ID, as well as your Team ID (displayed at the top right of the 
 ```php
 'connections' => [
     'apn' => [
-        'production' => true,
         'key_id' => env('APN_KEY_ID'),
         'team_id' => env('APN_TEAM_ID'),
         'app_bundle_id' => env('APN_BUNDLE_ID'),
         'private_key_content' => env('APN_PRIVATE_KEY'),
+        'production' => env('APN_PRODUCTION', true),
     ],
 ],
 ```

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -8,20 +8,6 @@ use Pushok\Client;
 class ApnChannel
 {
     /**
-     * The sandbox environment identifier.
-     *
-     * @var int
-     */
-    const SANDBOX = 0;
-
-    /**
-     * The production environment identifier.
-     *
-     * @var int
-     */
-    const PRODUCTION = 1;
-
-    /**
      * The APNS client.
      *
      * @var \Pushok\Client

--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -17,15 +17,13 @@ class ApnServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->bind(Token::class, function ($app) {
-            $options = Arr::except($app['config']['broadcasting.connections.apn'], 'environment');
+            $options = Arr::except($app['config']['broadcasting.connections.apn'], 'production');
 
             return Token::create($options);
         });
 
         $this->app->bind(Client::class, function ($app) {
-            $production = $app['config']['broadcasting.connections.apn.environment'] === ApnChannel::PRODUCTION;
-
-            return new Client($app->make(Token::class), $production);
+            return new Client($app->make(Token::class), $app['config']['broadcasting.connections.apn.production']);
         });
     }
 }


### PR DESCRIPTION
The constants were held over from a previous implementation that required the use of `0`/`1` - but now we can just us a boolean.