### PR TITLE
Add support for Laravel 7.0 (#81)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "mockery/mockery": "~1.3.0",
-        "phpunit/phpunit": "~9.0",
+        "phpunit/phpunit": "~8.0",
         "squizlabs/php_codesniffer": "~3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "edamov/pushok": "^0.10.4",
-        "illuminate/config": "^6.0",
-        "illuminate/events": "^6.0",
-        "illuminate/notifications": "^6.0",
-        "illuminate/support": "^6.0"
+        "illuminate/config": "^7.0",
+        "illuminate/events": "^7.0",
+        "illuminate/notifications": "^7.0",
+        "illuminate/support": "^7.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.3.0",
-        "phpunit/phpunit": "~8.2",
+        "phpunit/phpunit": "~9.0",
         "squizlabs/php_codesniffer": "~3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "mockery/mockery": "~1.3.0",
-        "phpunit/phpunit": "~8.0",
+        "phpunit/phpunit": "~8.2",
         "squizlabs/php_codesniffer": "~3.5"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,7 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
-    <logging> issue
+    <logging>
         <log type="junit" target="build/report.junit.xml"/>
         <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,8 +19,7 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
+    <logging> issue
         <log type="junit" target="build/report.junit.xml"/>
         <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>


### PR DESCRIPTION
Bump dependencies, support minimum PHP from Laravel 7.0.

Closes #81