### PR TITLE
Add VoIP support with additional channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ return ApnMessage::create()
 
 ### VoIP push notifications
 
-Sending VoIP push notifications is very similar. You just need to use a special `ApnVoipChannel` channel.
+Sending VoIP push notifications is very similar. You just need to use the `ApnVoipChannel` channel with `ApnVoipMessage` (which has the same API has a regular `ApnMessage`).
 
 ```php
 use NotificationChannels\Apn\ApnVoipChannel;
-use NotificationChannels\Apn\ApnMessage;
+use NotificationChannels\Apn\ApnVoipMessage;
 use Illuminate\Notifications\Notification;
 
 class AccountApproved extends Notification
@@ -116,8 +116,7 @@ class AccountApproved extends Notification
 
     public function toApnVoip($notifiable)
     {
-        return ApnMessage::create()
-            ->pushType('voip')
+        return ApnVoipMessage::create()
             ->badge(1);
     }
 }

--- a/README.md
+++ b/README.md
@@ -98,6 +98,40 @@ return ApnMessage::create()
     ->via($customClient)
 ```
 
+### VoIP push notifications
+
+Sending VoIP push notifications is very similar. You just need to use a special `ApnVoipChannel` channel.
+
+```php
+use NotificationChannels\Apn\ApnVoipChannel;
+use NotificationChannels\Apn\ApnMessage;
+use Illuminate\Notifications\Notification;
+
+class AccountApproved extends Notification
+{
+    public function via($notifiable)
+    {
+        return [ApnVoipChannel::class];
+    }
+
+    public function toApnVoip($notifiable)
+    {
+        return ApnMessage::create()
+            ->pushType('voip')
+            ->badge(1);
+    }
+}
+```
+
+In your `notifiable` model, make sure to include a `routeNotificationForApnVoip()` method, which return one or an array of tokens.
+
+```php
+public function routeNotificationForApnVoip()
+{
+    return $this->apn_voip_token;
+}
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/ApnVoipChannel.php
+++ b/src/ApnVoipChannel.php
@@ -2,11 +2,7 @@
 
 namespace NotificationChannels\Apn;
 
-use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notification;
-use Pushok\Client;
-use Pushok\Response;
 
 class ApnVoipChannel extends ApnChannel
 {

--- a/src/ApnVoipChannel.php
+++ b/src/ApnVoipChannel.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace NotificationChannels\Apn;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\Events\NotificationFailed;
+use Illuminate\Notifications\Notification;
+use Pushok\Client;
+use Pushok\Response;
+
+class ApnVoipChannel extends ApnChannel
+{
+    /**
+     * Send the notification to Apple Push Notification Service.
+     *
+     * @param mixed $notifiable
+     * @param \Illuminate\Notifications\Notification $notification
+     * @return array|void
+     */
+    public function send($notifiable, Notification $notification)
+    {
+        $tokens = (array) $notifiable->routeNotificationFor('apn_voip', $notification);
+
+        if (empty($tokens)) {
+            return;
+        }
+
+        $message = $notification->toApnVoip($notifiable);
+
+        $responses = $this->sendNotifications(
+            $message->client ?? $this->client,
+            $message,
+            $tokens
+        );
+
+        $this->dispatchEvents($notifiable, $notification, $responses);
+
+        return $responses;
+    }
+}

--- a/src/ApnVoipMessage.php
+++ b/src/ApnVoipMessage.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace NotificationChannels\Apn;
+
+class ApnVoipMessage extends ApnMessage
+{
+    /**
+     * Value indicating when the message will expire.
+     *
+     * @var \string
+     */
+    public $pushType = 'voip';
+}

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -4,11 +4,8 @@ namespace NotificationChannels\Apn\Tests;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Events\NotificationFailed;
-use Illuminate\Notifications\Notifiable;
-use Illuminate\Notifications\Notification;
 use Mockery;
 use NotificationChannels\Apn\ApnChannel;
-use NotificationChannels\Apn\ApnMessage;
 use Pushok\Client;
 use Pushok\Response;
 

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -8,8 +8,8 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Mockery;
 use NotificationChannels\Apn\ApnChannel;
-use NotificationChannels\Apn\ApnVoipChannel;
 use NotificationChannels\Apn\ApnMessage;
+use NotificationChannels\Apn\ApnVoipChannel;
 use Pushok\Client;
 use Pushok\Response;
 

--- a/tests/ApnVoipMessageTest.php
+++ b/tests/ApnVoipMessageTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace NotificationChannels\Apn\Tests;
+
+use DateTime;
+use Mockery;
+use NotificationChannels\Apn\ApnVoipMessage;
+use Pushok\Client;
+
+class ApnVoipMessageTest extends TestCase
+{
+    /** @test */
+    public function it_defaults_push_type_to_voip()
+    {
+        $message = new ApnVoipMessage;
+
+        $this->assertEquals('voip', $message->pushType);
+    }
+}

--- a/tests/ApnVoipMessageTest.php
+++ b/tests/ApnVoipMessageTest.php
@@ -2,10 +2,7 @@
 
 namespace NotificationChannels\Apn\Tests;
 
-use DateTime;
-use Mockery;
 use NotificationChannels\Apn\ApnVoipMessage;
-use Pushok\Client;
 
 class ApnVoipMessageTest extends TestCase
 {

--- a/tests/TestNotifiable.php
+++ b/tests/TestNotifiable.php
@@ -2,6 +2,8 @@
 
 namespace NotificationChannels\Apn\Tests;
 
+use Illuminate\Notifications\Notifiable;
+
 class TestNotifiable
 {
     use Notifiable;

--- a/tests/TestNotifiable.php
+++ b/tests/TestNotifiable.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace NotificationChannels\Apn\Tests;
+
+class TestNotifiable
+{
+    use Notifiable;
+
+    /**
+     * @return array
+     */
+    public function routeNotificationForApn()
+    {
+        return [
+            '662cfe5a69ddc65cdd39a1b8f8690647778204b064df7b264e8c4c254f94fdd8',
+            '662cfe5a69ddc65cdd39a1b8f8690647778204b064df7b264e8c4c254f94fdd9',
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function routeNotificationForApnVoip()
+    {
+        return [
+            '662cfe5a69ddc65cdd39a1b8f8690647778204b064df7b264e8c4c254f94fdd1',
+            '662cfe5a69ddc65cdd39a1b8f8690647778204b064df7b264e8c4c254f94fdd2',
+        ];
+    }
+}

--- a/tests/TestNotification.php
+++ b/tests/TestNotification.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace NotificationChannels\Apn\Tests;
+
+class TestNotification extends Notification
+{
+    public function toApn($notifiable)
+    {
+        return new ApnMessage('title');
+    }
+
+    public function toApnVoip($notifiable)
+    {
+        return (new ApnMessage)
+            ->pushType('voip');
+    }
+}

--- a/tests/TestNotification.php
+++ b/tests/TestNotification.php
@@ -2,6 +2,10 @@
 
 namespace NotificationChannels\Apn\Tests;
 
+use Illuminate\Notifications\Notification;
+use NotificationChannels\Apn\ApnMessage;
+use NotificationChannels\Apn\ApnVoipMessage;
+
 class TestNotification extends Notification
 {
     public function toApn($notifiable)
@@ -11,7 +15,6 @@ class TestNotification extends Notification
 
     public function toApnVoip($notifiable)
     {
-        return (new ApnMessage)
-            ->pushType('voip');
+        return new ApnVoipMessage('title');
     }
 }

--- a/tests/TestNotificationWithClient.php
+++ b/tests/TestNotificationWithClient.php
@@ -2,6 +2,10 @@
 
 namespace NotificationChannels\Apn\Tests;
 
+use Illuminate\Notifications\Notification;
+use NotificationChannels\Apn\ApnMessage;
+use NotificationChannels\Apn\ApnVoipMessage;
+
 class TestNotificationWithClient extends Notification
 {
     protected $client;
@@ -18,6 +22,6 @@ class TestNotificationWithClient extends Notification
 
     public function toApnVoip($notifiable)
     {
-        return (new ApnMessage)->pushType('voip')->via($this->client);
+        return (new ApnVoipMessage)->via($this->client);
     }
 }

--- a/tests/TestNotificationWithClient.php
+++ b/tests/TestNotificationWithClient.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace NotificationChannels\Apn\Tests;
+
+class TestNotificationWithClient extends Notification
+{
+    protected $client;
+
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
+
+    public function toApn($notifiable)
+    {
+        return (new ApnMessage('title'))->via($this->client);
+    }
+
+    public function toApnVoip($notifiable)
+    {
+        return (new ApnMessage)->pushType('voip')->via($this->client);
+    }
+}


### PR DESCRIPTION
This extends #90 - I thought I was pushing straight onto that PR but seems I did something wrong. This PR still includes @chimit's work.

* I added a separate `ApnVoipMessage` that just sets the push type out of the box. It extends `ApnMessage` so you can use it just the same, with less boilerplate.
* I split the tests so the two channels are tested independently. This also meant breaking out some stubs so they could be re-used.
* I did look to reduce some duplication between the channels but that can always happen later. The `send` method isn't that long and it's very clear what's going on.