### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Collect your Key ID, as well as your Team ID (displayed at the top right of the 
         'team_id' => env('APN_TEAM_ID'),
         'app_bundle_id' => env('APN_BUNDLE_ID'),
         'private_key_content' => env('APN_PRIVATE_KEY'),
-        'production' => env('APN_PRODUCTION', true),
+        'environment' => (int)env('APN_PRODUCTION', 1),
     ],
 ],
 ```


### PR DESCRIPTION
Wrong configuration file - spent few hours until I found the issue.

src/ApnServiceProvider.php:26 uses this check method:

$production = $app['config']['broadcasting.connections.apn.environment'] === ApnChannel::PRODUCTION;

And the name of setting is "environment", not "production".

My production APN channel was not working in TestFlight/App Store until I changed the setting.