### PR TITLE
Fix channel type of NotificationFailed events

### DIFF
--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -96,7 +96,7 @@ class ApnChannel
                 continue;
             }
 
-            $event = new NotificationFailed($notifiable, $notification, $this, [
+            $event = new NotificationFailed($notifiable, $notification, static::class, [
                 'id' => $response->getApnsId(),
                 'token' => $response->getDeviceToken(),
                 'error' => $response->getErrorReason(),

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -62,4 +62,23 @@ class ApnChannelTest extends TestCase
 
         $this->channel->send(new TestNotifiable, new TestNotification);
     }
+
+    /** @test */
+    public function it_dispatches_failed_notification_events_with_correct_channel()
+    {
+        $this->events->shouldReceive('dispatch')
+            ->withArgs(function (NotificationFailed $notificationFailed) {
+                return $notificationFailed->channel === ApnChannel::class;
+            });
+
+        $this->client->shouldReceive('addNotification');
+        $this->client->shouldReceive('push')
+            ->once()
+            ->andReturn([
+                new Response(200, 'headers', 'body'),
+                new Response(400, 'headers', 'body'),
+            ]);
+
+        $this->channel->send(new TestNotifiable, new TestNotification);
+    }
 }


### PR DESCRIPTION
This commit changes the channel property that is set on the dispatched
NotificationFailed events from a class instance to a string representing
the class name. This is done because the property is documented as a
string property on Illuminate's side, and if an application assumes that
this package adheres to that documentation, runtime errors may occur.