### PR TITLE
Automatically refresh tokens after 20 minutes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "require": {
         "php": "^7.2.5",
         "edamov/pushok": "^0.11",
+        "illuminate/cache": "^7.0",
         "illuminate/config": "^7.0",
         "illuminate/events": "^7.0",
         "illuminate/notifications": "^7.0",

--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -11,11 +11,11 @@ use Pushok\Response;
 class ApnChannel
 {
     /**
-     * The APNS client.
+     * The Pushok\Client factory.
      *
-     * @var \Pushok\Client
+     * @var \NotificationChannels\Apn\ClientFactory
      */
-    protected $client;
+    protected $factory;
 
     /**
      * The event dispatcher.
@@ -27,12 +27,12 @@ class ApnChannel
     /**
      * Create a new channel instance.
      *
-     * @param  \Pushok\Client  $client
+     * @param  \NotificationChannels\Apn\ClientFactory  $factory
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      */
-    public function __construct(Client $client, Dispatcher $events)
+    public function __construct(ClientFactory $factory, Dispatcher $events)
     {
-        $this->client = $client;
+        $this->factory = $factory;
         $this->events = $events;
     }
 
@@ -53,11 +53,9 @@ class ApnChannel
 
         $message = $notification->toApn($notifiable);
 
-        $responses = $this->sendNotifications(
-            $message->client ?? $this->client,
-            $message,
-            $tokens
-        );
+        $client = $message->client ?? $this->factory->instance();
+
+        $responses = $this->sendNotifications($client, $message, $tokens);
 
         $this->dispatchEvents($notifiable, $notification, $responses);
 

--- a/src/ApnVoipChannel.php
+++ b/src/ApnVoipChannel.php
@@ -23,8 +23,9 @@ class ApnVoipChannel extends ApnChannel
 
         $message = $notification->toApnVoip($notifiable);
 
+        $client = $message->client ?? $this->factory->instance();
+
         $responses = $this->sendNotifications(
-            $message->client ?? $this->client,
             $message,
             $tokens
         );

--- a/src/ApnVoipChannel.php
+++ b/src/ApnVoipChannel.php
@@ -25,10 +25,7 @@ class ApnVoipChannel extends ApnChannel
 
         $client = $message->client ?? $this->factory->instance();
 
-        $responses = $this->sendNotifications(
-            $message,
-            $tokens
-        );
+        $responses = $this->sendNotifications($client, $message, $tokens);
 
         $this->dispatchEvents($notifiable, $notification, $responses);
 

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -4,6 +4,7 @@ namespace NotificationChannels\Apn;
 
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Carbon;
 use Pushok\Client;
 
 class ClientFactory
@@ -49,8 +50,8 @@ class ClientFactory
      */
     public function instance(): Client
     {
-        return $this->cache->remember(Client::class, now()->addMinutes(static::CACHE_MINUTES), function () {
-            $this->app->make(Client::class);
+        return $this->cache->remember(Client::class, Carbon::now()->addMinutes(static::CACHE_MINUTES), function () {
+            return $this->app->make(Client::class);
         });
     }
 }

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace NotificationChannels\Apn;
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Container\Container;
+use Pushok\Client;
+
+class ClientFactory
+{
+    /**
+     * The number of minutes to cache the client.
+     *
+     * @var int
+     */
+    const CACHE_MINUTES = 20;
+
+    /**
+     * The app instance.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $app;
+
+    /**
+     * The cache repository instance.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected $cache;
+
+    /**
+     * Create a new factory instance.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $app
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
+     * @return void
+     */
+    public function __construct(Container $app, Repository $cache)
+    {
+        $this->app = $app;
+        $this->cache = $cache;
+    }
+
+    /**
+     * Get an instance of the Pushok client, holding on to each in the cache for the given length of time.
+     *
+     * @return \Pushok\Client
+     */
+    public function instance(): Client
+    {
+        return $this->cache->remember(Client::class, now()->addMinutes(static::CACHE_MINUTES), function () {
+            $this->app->make(Client::class);
+        });
+    }
+}

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Mockery;
 use NotificationChannels\Apn\ApnChannel;
+use NotificationChannels\Apn\ClientFactory;
 use Pushok\Client;
 use Pushok\Response;
 
@@ -19,8 +20,10 @@ class ApnChannelTest extends TestCase
     public function setUp(): void
     {
         $this->client = Mockery::mock(Client::class);
+        $this->factory = Mockery::mock(ClientFactory::class);
+        $this->factory->shouldReceive('instance')->andReturn($this->client);
         $this->events = Mockery::mock(Dispatcher::class);
-        $this->channel = new ApnChannel($this->client, $this->events);
+        $this->channel = new ApnChannel($this->factory, $this->events);
     }
 
     /** @test */

--- a/tests/ApnVoipChannelTest.php
+++ b/tests/ApnVoipChannelTest.php
@@ -9,6 +9,7 @@ use Illuminate\Notifications\Notification;
 use Mockery;
 use NotificationChannels\Apn\ApnMessage;
 use NotificationChannels\Apn\ApnVoipChannel;
+use NotificationChannels\Apn\ClientFactory;
 use Pushok\Client;
 use Pushok\Response;
 
@@ -22,8 +23,10 @@ class ApnVoipChannelTest extends TestCase
     public function setUp(): void
     {
         $this->client = Mockery::mock(Client::class);
+        $this->factory = Mockery::mock(ClientFactory::class);
+        $this->factory->shouldReceive('instance')->andReturn($this->client);
         $this->events = Mockery::mock(Dispatcher::class);
-        $this->channel = new ApnVoipChannel($this->client, $this->events);
+        $this->channel = new ApnVoipChannel($this->factory, $this->events);
     }
 
     /** @test */

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NotificationChannels\Apn\Tests;
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Carbon;
+use Mockery;
+use NotificationChannels\Apn\ClientFactory;
+use Pushok\Client;
+
+class ClientFactoryTest extends TestCase
+{
+    protected $app;
+    protected $cache;
+    protected $factory;
+
+    public function setUp(): void
+    {
+        $this->app = Mockery::mock(Container::class);
+        $this->cache = Mockery::mock(Repository::class);
+        $this->factory = new ClientFactory($this->app, $this->cache);
+    }
+
+    /** @test */
+    public function it_returns_an_instance_through_the_cache()
+    {
+        $client = Mockery::mock(Client::class);
+
+        // $this->app->shouldReceive('make')
+        //     ->with(Client::class)
+        //     ->andReturn($client);
+
+        $this->cache->shouldReceive('remember')
+            ->with(Client::class, Mockery::type(Carbon::class), Mockery::on(function () {
+                return true;
+            }))
+            ->andReturn($client);
+
+        $result = $this->factory->instance();
+
+        $this->assertSame($client, $result);
+    }
+}

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -27,13 +27,13 @@ class ClientFactoryTest extends TestCase
     {
         $client = Mockery::mock(Client::class);
 
-        // $this->app->shouldReceive('make')
-        //     ->with(Client::class)
-        //     ->andReturn($client);
+        $this->app->shouldReceive('make')
+            ->with(Client::class)
+            ->andReturn($client);
 
         $this->cache->shouldReceive('remember')
-            ->with(Client::class, Mockery::type(Carbon::class), Mockery::on(function () {
-                return true;
+            ->with(Client::class, Mockery::type(Carbon::class), Mockery::on(function ($closure) use ($client) {
+                return $client == $closure();
             }))
             ->andReturn($client);
 


### PR DESCRIPTION
As per #98 we have an issue where tokens are expiring and notifications stop being delivered. Because the convention of failed notifications is a `NotificationFailed` event it's easy for these to go unnoticed.

Apple wants us to reuse tokens and refresh them no more than every 20 minutes, and no less than every 60 minutes. The Pushok library we use for notifications doesn't have a solution for this problem, it's something that's pushed onto the consumer.

As this library is only (intended to be) used in the context of a Laravel application it's safe to assume we've got a cache driver too.

This introduces a layer between the app generating an instance of Pushok and the channel - a "factory" (I considered calling it a repository too, I don't think either answer is particularly accurate) that will build a Pushok instance on demand, and keep it in the cache for at least 20 minutes.

This means it should still work in the case of long-running workers that hold an instance of the channel in memory - as the client will need to be fetched through the cache each time it's used.