### PR TITLE
Allow a badge value of zero

### DIFF
--- a/src/ApnAdapter.php
+++ b/src/ApnAdapter.php
@@ -52,7 +52,7 @@ class ApnAdapter
             ->setContentAvailability((bool) $message->contentAvailable)
             ->setMutableContent((bool) $message->mutableContent);
 
-        if ($badge = $message->badge) {
+        if (is_int($badge = $message->badge)) {
             $payload->setBadge($badge);
         }
 

--- a/tests/ApnAdapterTest.php
+++ b/tests/ApnAdapterTest.php
@@ -66,6 +66,16 @@ class ApnAdapterTest extends TestCase
     }
 
     /** @test */
+    public function it_adapts_badge_clear()
+    {
+        $message = (new ApnMessage)->badge(0);
+
+        $notification = $this->adapter->adapt($message, 'token');
+
+        $this->assertSame(0, $notification->getPayload()->getBadge());
+    }
+
+    /** @test */
     public function it_adapts_sound()
     {
         $message = (new ApnMessage)->sound('sound');


### PR DESCRIPTION
This adds an `is_int` check to `$badge` instead of relying on the coercion to a bool where a value of zero would evaluate to false and cause the badge value of zero to *not* be added to the payload.

This is consistent with the checks that pushok performs itself on the badge value