### PR TITLE
Updated the Pushok token creation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ public function routeNotificationForApn()
 If you need to provide a custom configuration for a message you can provide an instance of a [Pushok](https://github.com/edamov/pushok) client and it will be used instead of the default one.
 
 ```php
-$customClient = new Pushok\Client(new Pushok\Token($options));
+$customClient = new Pushok\Client(Pushok\AuthProvider\Token::create($options));
 
 return ApnMessage::create()
     ->title('Account approved')


### PR DESCRIPTION
The Token creation method is different than the one pointed in documentation, just updated it to match the current version