### PR TITLE
Do not always set content-available and mutable-content

### DIFF
--- a/src/ApnAdapter.php
+++ b/src/ApnAdapter.php
@@ -48,9 +48,15 @@ class ApnAdapter
         }
 
         $payload = Payload::create()
-            ->setAlert($alert)
-            ->setContentAvailability((bool) $message->contentAvailable)
-            ->setMutableContent((bool) $message->mutableContent);
+            ->setAlert($alert);
+
+        if ($contentAvailable = $message->contentAvailable) {
+            $payload->setContentAvailability((bool) $message->contentAvailable);
+        }
+
+        if ($mutableContent = $message->mutableContent) {
+            $payload->setMutableContent((bool) $message->mutableContent);
+        }
 
         if (is_int($badge = $message->badge)) {
             $payload->setBadge($badge);

--- a/tests/ApnAdapterTest.php
+++ b/tests/ApnAdapterTest.php
@@ -46,6 +46,16 @@ class ApnAdapterTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_set_content_available_by_default()
+    {
+        $message = (new ApnMessage);
+
+        $notification = $this->adapter->adapt($message, 'token');
+
+        $this->assertNull($notification->getPayload()->isContentAvailable());
+    }
+
+    /** @test */
     public function it_adapts_mutable_content()
     {
         $message = (new ApnMessage)->mutableContent(true);
@@ -53,6 +63,16 @@ class ApnAdapterTest extends TestCase
         $notification = $this->adapter->adapt($message, 'token');
 
         $this->assertTrue($notification->getPayload()->hasMutableContent());
+    }
+
+    /** @test */
+    public function it_does_not_set_mutable_content_by_default()
+    {
+        $message = (new ApnMessage);
+
+        $notification = $this->adapter->adapt($message, 'token');
+
+        $this->assertNull($notification->getPayload()->hasMutableContent());
     }
 
     /** @test */


### PR DESCRIPTION
Fixes: #112 

This could possibly introduce issues for any users who are expecting the value to be `0` by default though.