### PR TITLE
Allow to use JSON / Array as custom Alert field

### DIFF
--- a/src/ApnAdapter.php
+++ b/src/ApnAdapter.php
@@ -17,35 +17,40 @@ class ApnAdapter
      */
     public function adapt(ApnMessage $message, string $token)
     {
-        $alert = Alert::create();
+        if($message->customAlert){
+            $alert = $message->customAlert;
+        } else {
+            $alert = Alert::create();
 
-        if ($title = $message->title) {
-            $alert->setTitle($title);
-        }
+            if ($title = $message->title) {
+                $alert->setTitle($title);
+            }
 
-        if ($body = $message->body) {
-            $alert->setBody($body);
-        }
+            if ($body = $message->body) {
+                $alert->setBody($body);
+            }
 
-        if ($titleLocArgs = $message->titleLocArgs) {
-            $alert->setTitleLocArgs($titleLocArgs);
-        }
+            if ($titleLocArgs = $message->titleLocArgs) {
+                $alert->setTitleLocArgs($titleLocArgs);
+            }
 
-        if ($titleLocKey = $message->titleLocKey) {
-            $alert->setTitleLocKey($titleLocKey);
-        }
+            if ($titleLocKey = $message->titleLocKey) {
+                $alert->setTitleLocKey($titleLocKey);
+            }
 
-        if ($actionLocKey = $message->actionLocKey) {
-            $alert->setActionLocKey($actionLocKey);
-        }
+            if ($actionLocKey = $message->actionLocKey) {
+                $alert->setActionLocKey($actionLocKey);
+            }
 
-        if ($locArgs = $message->locArgs) {
-            $alert->setLocArgs($locArgs);
-        }
+            if ($locArgs = $message->locArgs) {
+                $alert->setLocArgs($locArgs);
+            }
 
-        if ($locKey = $message->locKey) {
-            $alert->setLocKey($locKey);
+            if ($locKey = $message->locKey) {
+                $alert->setLocKey($locKey);
+            }
         }
+        
 
         $payload = Payload::create()
             ->setAlert($alert);

--- a/src/ApnAdapter.php
+++ b/src/ApnAdapter.php
@@ -17,7 +17,7 @@ class ApnAdapter
      */
     public function adapt(ApnMessage $message, string $token)
     {
-        if($message->customAlert){
+        if ($message->customAlert) {
             $alert = $message->customAlert;
         } else {
             $alert = Alert::create();
@@ -50,7 +50,6 @@ class ApnAdapter
                 $alert->setLocKey($locKey);
             }
         }
-        
 
         $payload = Payload::create()
             ->setAlert($alert);

--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -118,6 +118,13 @@ class ApnMessage
      * @var int|null
      */
     public $mutableContent = null;
+    
+    /**
+    * Custom alert for Edamov/Pushok
+    * 
+    * @var string|array|null
+    */
+    public $customAlert = null;
 
     /**
      * @param string|null $title
@@ -335,6 +342,20 @@ class ApnMessage
     {
         $this->custom[$key] = $value;
 
+        return $this;
+    }
+    
+    /**
+    * Sets custom alert value as JSON or Array
+    * 
+    * @param string|array $customAlert
+    * 
+    * @return $this
+    */
+    public function setCustomAlert($customAlert)
+    {
+        $this->customAlert = $customAlert;
+        
         return $this;
     }
 

--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -120,10 +120,10 @@ class ApnMessage
     public $mutableContent = null;
     
     /**
-    * Custom alert for Edamov/Pushok
-    * 
-    * @var string|array|null
-    */
+     * Custom alert for Edamov/Pushok
+     * 
+     * @var string|array|null
+     */
     public $customAlert = null;
 
     /**
@@ -346,12 +346,12 @@ class ApnMessage
     }
     
     /**
-    * Sets custom alert value as JSON or Array
-    * 
-    * @param string|array $customAlert
-    * 
-    * @return $this
-    */
+     * Sets custom alert value as JSON or Array
+     * 
+     * @param string|array $customAlert
+     * 
+     * @return $this
+     */
     public function setCustomAlert($customAlert)
     {
         $this->customAlert = $customAlert;

--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -118,10 +118,10 @@ class ApnMessage
      * @var int|null
      */
     public $mutableContent = null;
-    
+
     /**
      * Custom alert for Edamov/Pushok.
-     * 
+     *
      * @var string|array|null
      */
     public $customAlert = null;
@@ -344,18 +344,18 @@ class ApnMessage
 
         return $this;
     }
-    
+
     /**
      * Sets custom alert value as JSON or Array.
-     * 
+     *
      * @param string|array $customAlert
-     * 
+     *
      * @return $this
      */
     public function setCustomAlert($customAlert)
     {
         $this->customAlert = $customAlert;
-        
+
         return $this;
     }
 

--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -346,7 +346,7 @@ class ApnMessage
     }
     
     /**
-     * Sets custom alert value as JSON or Arrayю
+     * Sets custom alert value as JSON or Array.
      * 
      * @param string|array $customAlert
      * 

--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -120,7 +120,7 @@ class ApnMessage
     public $mutableContent = null;
     
     /**
-     * Custom alert for Edamov/Pushok
+     * Custom alert for Edamov/Pushok.
      * 
      * @var string|array|null
      */
@@ -346,7 +346,7 @@ class ApnMessage
     }
     
     /**
-     * Sets custom alert value as JSON or Array
+     * Sets custom alert value as JSON or Arrayю
      * 
      * @param string|array $customAlert
      * 


### PR DESCRIPTION
Edamov/Pushok allowed to use strings as Alert value. 
I created two pull requests (this and another in Pushok - https://github.com/edamov/pushok/pull/131 - to allow use not only JSON, but array).