### PR TITLE
Adding ability to leverage 'InterruptionLevel' in pushok

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "edamov/pushok": "^0.13",
+        "edamov/pushok": "^0.14",
         "illuminate/cache": "^8.0|^9.0",
         "illuminate/config": "^8.0|^9.0",
         "illuminate/events": "^8.0|^9.0",

--- a/src/ApnAdapter.php
+++ b/src/ApnAdapter.php
@@ -73,6 +73,10 @@ class ApnAdapter
             $payload->setSound($sound);
         }
 
+        if ($interruptionLevel = $message->interruptionLevel) {
+            $payload->setInterruptionLevel($interruptionLevel);
+        }
+
         if ($category = $message->category) {
             $payload->setCategory($category);
         }

--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -50,6 +50,13 @@ class ApnMessage
     public $sound;
 
     /**
+     * The interruption level of the notification.
+     *
+     * @var string|null
+     */
+    public $interruptionLevel;
+
+    /**
      * The category for action button.
      *
      * @var string|null
@@ -248,6 +255,19 @@ class ApnMessage
     public function sound($sound = 'default')
     {
         $this->sound = $sound;
+
+        return $this;
+    }
+
+    /**
+     * Set the interruptionLevel of the notification.
+     *
+     * @param string|null  $interruptionLevel
+     * @return $this
+     */
+    public function interruptionLevel($interruptionLevel = 'active')
+    {
+        $this->interruptionLevel = $interruptionLevel;
 
         return $this;
     }

--- a/tests/ApnAdapterTest.php
+++ b/tests/ApnAdapterTest.php
@@ -116,6 +116,16 @@ class ApnAdapterTest extends TestCase
     }
 
     /** @test */
+    public function it_adapts_interruption_level()
+    {
+        $message = (new ApnMessage)->interruptionLevel('interruption-level');
+
+        $notification = $this->adapter->adapt($message, 'token');
+
+        $this->assertEquals('interruption-level', $notification->getPayload()->getInterruptionLevel());
+    }
+
+    /** @test */
     public function it_adapts_category()
     {
         $message = (new ApnMessage)->category('category');

--- a/tests/ApnMessageTest.php
+++ b/tests/ApnMessageTest.php
@@ -78,6 +78,17 @@ class ApnMessageTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_interruption_level()
+    {
+        $message = new ApnMessage;
+
+        $result = $message->interruptionLevel('critical');
+
+        $this->assertEquals('critical', $message->interruptionLevel);
+        $this->assertEquals($message, $result);
+    }
+
+    /** @test */
     public function it_can_set_sound_to_default()
     {
         $message = new ApnMessage;


### PR DESCRIPTION
Adding Apple Push Notification 'interruption-level' support. Allows for sending 'passive', 'active', 'time-sensitive', and 'critical' level notifications to recipients.