### PR TITLE
Allow Pushok sound payload as sound

### DIFF
--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -37,7 +37,7 @@ class ApnMessage
     /**
      * The sound of the notification.
      */
-    public ?string $sound = null;
+    public null|string|\Pushok\Payload\Sound $sound = null;
 
     /**
      * The interruption level of the notification.
@@ -199,7 +199,7 @@ class ApnMessage
     /**
      * Set the sound of the notification.
      */
-    public function sound(?string $sound = 'default'): self
+    public function sound(null|string|\Pushok\Payload\Sound $sound = 'default'): self
     {
         $this->sound = $sound;
 

--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -4,6 +4,7 @@ namespace NotificationChannels\Apn;
 
 use DateTime;
 use Pushok\Client;
+use Pushok\Payload\Sound;
 
 class ApnMessage
 {
@@ -37,7 +38,7 @@ class ApnMessage
     /**
      * The sound of the notification.
      */
-    public null|string|\Pushok\Payload\Sound $sound = null;
+    public null|string|Sound $sound = null;
 
     /**
      * The interruption level of the notification.
@@ -199,7 +200,7 @@ class ApnMessage
     /**
      * Set the sound of the notification.
      */
-    public function sound(null|string|\Pushok\Payload\Sound $sound = 'default'): self
+    public function sound(null|string|Sound $sound = 'default'): self
     {
         $this->sound = $sound;
 


### PR DESCRIPTION
Pushok allows it, therefore we should support it.
Grants critical notification and volume apn configuration.

[see Payload.php](https://github.com/edamov/pushok/blob/4dd7a9d3dcd02c7ee55cc96b0e5cf184a093c275/src/Payload.php#L251C12-L251C20)
```
    public function setSound($sound): Payload
    {
        if ($sound instanceof Sound || is_string($sound)) {
            $this->sound = $sound;
        }

        return $this;
    }
```