### PR TITLE
Add interruption level enum

### DIFF
--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -210,9 +210,11 @@ class ApnMessage
     /**
      * Set the interruptionLevel of the notification.
      */
-    public function interruptionLevel(?string $interruptionLevel = 'active'): self
+    public function interruptionLevel(string|ApnMessageInterruptionLevel|null $interruptionLevel = 'active'): self
     {
-        $this->interruptionLevel = $interruptionLevel;
+        $this->interruptionLevel = $interruptionLevel instanceof ApnMessageInterruptionLevel
+            ? $interruptionLevel->value
+            : $interruptionLevel;
 
         return $this;
     }

--- a/src/ApnMessageInterruptionLevel.php
+++ b/src/ApnMessageInterruptionLevel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace NotificationChannels\Apn;
+
+enum ApnMessageInterruptionLevel: string
+{
+    case Active = 'active';
+    case Critical = 'critical';
+    case Passive = 'passive';
+    case TimeSensitive = 'time-sensitive';
+}

--- a/tests/ApnMessageTest.php
+++ b/tests/ApnMessageTest.php
@@ -5,6 +5,7 @@ namespace NotificationChannels\Apn\Tests;
 use DateTime;
 use Mockery;
 use NotificationChannels\Apn\ApnMessage;
+use NotificationChannels\Apn\ApnMessageInterruptionLevel;
 use Pushok\Client;
 
 class ApnMessageTest extends TestCase
@@ -78,11 +79,22 @@ class ApnMessageTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_interruption_level()
+    public function it_can_set_interruption_level_as_string()
     {
         $message = new ApnMessage;
 
         $result = $message->interruptionLevel('critical');
+
+        $this->assertEquals('critical', $message->interruptionLevel);
+        $this->assertEquals($message, $result);
+    }
+
+    /** @test */
+    public function it_can_set_interruption_level_as_enum()
+    {
+        $message = new ApnMessage;
+
+        $result = $message->interruptionLevel(ApnMessageInterruptionLevel::Critical);
 
         $this->assertEquals('critical', $message->interruptionLevel);
         $this->assertEquals($message, $result);


### PR DESCRIPTION
I've added an Enum for APNs InterruptionLevels:
https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel

I've tried to do it in a way that won't risk introducing any backwards compatibility issues

# Things I considered
* I didn't want to force the `interruptionLevel` to use Enum only as it would break all older versions
* I could've introduced a new method, but that feels ugly (but so does this way with 2 potential types for the parameter)
* I could've passed the `string` passed through the Enum::from aswell for validation, but would cause Fatal issues if anyone is passing something strange
* I could've set the property `ApnMessage::$interruptionLevel` to be of type `ApnMessageInterruptionLevel` but as it's public, theres a chance people are editing it manually