### PR TITLE
Drop support for older PHP/Laravel version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.2]
-        laravel: ['9.*', '10.*', '11.*']
+        php: [8.2, 8.3, 8.4]
+        laravel: ['11.*', '12.*']
         stability: [prefer-lowest, prefer-stable]
         exclude:
           - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,18 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "edamov/pushok": "^0.18",
-        "illuminate/cache": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/config": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/events": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/notifications": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/cache": "^11.0|^12.0",
+        "illuminate/config": "^11.0|^12.0",
+        "illuminate/events": "^11.0|^12.0",
+        "illuminate/notifications": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0",
         "nesbot/carbon": "^2.66|^3.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.5.1",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^12.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {
@@ -42,9 +42,6 @@
         "sort-packages": true
     },
     "extra": {
-        "branch-alias": {
-            "dev-master": "0.2-dev"
-        },
         "laravel": {
             "providers": [
                 "NotificationChannels\\Apn\\ApnServiceProvider"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5.1",
-        "phpunit/phpunit": "^12.0",
+        "phpunit/phpunit": "^11.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name=":service_name Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
+<phpunit backupGlobals="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+>
+    <testsuites>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -312,7 +312,7 @@ class ApnMessage
     /**
      * Set the title-loc-args.
      */
-    public function titleLocArgs(array $titleLocArgs = null): self
+    public function titleLocArgs(?array $titleLocArgs = null): self
     {
         $this->titleLocArgs = $titleLocArgs;
 

--- a/tests/ApnAdapterTest.php
+++ b/tests/ApnAdapterTest.php
@@ -15,8 +15,7 @@ class ApnAdapterTest extends TestCase
         $this->adapter = new ApnAdapter;
     }
 
-    /** @test */
-    public function it_adapts_title()
+    public function test_it_adapts_title()
     {
         $message = (new ApnMessage)->title('title');
 
@@ -25,8 +24,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('title', $notification->getPayload()->getAlert()->getTitle());
     }
 
-    /** @test */
-    public function it_adapts_subtitle()
+    public function test_it_adapts_subtitle()
     {
         $message = (new ApnMessage)->subtitle('subtitle');
 
@@ -35,8 +33,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('subtitle', $notification->getPayload()->getAlert()->getSubtitle());
     }
 
-    /** @test */
-    public function it_adapts_body()
+    public function test_it_adapts_body()
     {
         $message = (new ApnMessage)->body('body');
 
@@ -45,8 +42,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('body', $notification->getPayload()->getAlert()->getBody());
     }
 
-    /** @test */
-    public function it_adapts_content_available()
+    public function test_it_adapts_content_available()
     {
         $message = (new ApnMessage)->contentAvailable(true);
 
@@ -55,8 +51,7 @@ class ApnAdapterTest extends TestCase
         $this->assertTrue($notification->getPayload()->isContentAvailable());
     }
 
-    /** @test */
-    public function it_does_not_set_content_available_by_default()
+    public function test_it_does_not_set_content_available_by_default()
     {
         $message = (new ApnMessage);
 
@@ -65,8 +60,7 @@ class ApnAdapterTest extends TestCase
         $this->assertNull($notification->getPayload()->isContentAvailable());
     }
 
-    /** @test */
-    public function it_adapts_mutable_content()
+    public function test_it_adapts_mutable_content()
     {
         $message = (new ApnMessage)->mutableContent(true);
 
@@ -75,8 +69,7 @@ class ApnAdapterTest extends TestCase
         $this->assertTrue($notification->getPayload()->hasMutableContent());
     }
 
-    /** @test */
-    public function it_does_not_set_mutable_content_by_default()
+    public function test_it_does_not_set_mutable_content_by_default()
     {
         $message = (new ApnMessage);
 
@@ -85,8 +78,7 @@ class ApnAdapterTest extends TestCase
         $this->assertNull($notification->getPayload()->hasMutableContent());
     }
 
-    /** @test */
-    public function it_adapts_badge()
+    public function test_it_adapts_badge()
     {
         $message = (new ApnMessage)->badge(1);
 
@@ -95,8 +87,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals(1, $notification->getPayload()->getBadge());
     }
 
-    /** @test */
-    public function it_adapts_badge_clear()
+    public function test_it_adapts_badge_clear()
     {
         $message = (new ApnMessage)->badge(0);
 
@@ -105,8 +96,7 @@ class ApnAdapterTest extends TestCase
         $this->assertSame(0, $notification->getPayload()->getBadge());
     }
 
-    /** @test */
-    public function it_adapts_sound()
+    public function test_it_adapts_sound()
     {
         $message = (new ApnMessage)->sound('sound');
 
@@ -115,8 +105,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('sound', $notification->getPayload()->getSound());
     }
 
-    /** @test */
-    public function it_adapts_interruption_level()
+    public function test_it_adapts_interruption_level()
     {
         $message = (new ApnMessage)->interruptionLevel('interruption-level');
 
@@ -125,8 +114,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('interruption-level', $notification->getPayload()->getInterruptionLevel());
     }
 
-    /** @test */
-    public function it_adapts_category()
+    public function test_it_adapts_category()
     {
         $message = (new ApnMessage)->category('category');
 
@@ -135,8 +123,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('category', $notification->getPayload()->getCategory());
     }
 
-    /** @test */
-    public function it_adapts_thread_id()
+    public function test_it_adapts_thread_id()
     {
         $message = (new ApnMessage)->threadId('threadId');
 
@@ -145,8 +132,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('threadId', $notification->getPayload()->getThreadId());
     }
 
-    /** @test */
-    public function it_adapts_custom()
+    public function test_it_adapts_custom()
     {
         $message = (new ApnMessage)->custom('key', 'value');
 
@@ -155,8 +141,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('value', $notification->getPayload()->getCustomValue('key'));
     }
 
-    /** @test */
-    public function it_adapts_custom_alert()
+    public function test_it_adapts_custom_alert()
     {
         $message = (new ApnMessage)->setCustomAlert('custom');
 
@@ -165,8 +150,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('custom', $notification->getPayload()->getAlert());
     }
 
-    /** @test */
-    public function it_adapts_push_type()
+    public function test_it_adapts_push_type()
     {
         $message = (new ApnMessage)->pushType('push type');
 
@@ -175,8 +159,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('push type', $notification->getPayload()->getPushType());
     }
 
-    /** @test */
-    public function it_adapts_expires_at()
+    public function test_it_adapts_expires_at()
     {
         $expiresAt = new DateTime('2000-01-01');
 
@@ -187,8 +170,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals($expiresAt, $notification->getExpirationAt());
     }
 
-    /** @test */
-    public function it_adapts_collapse_id()
+    public function test_it_adapts_collapse_id()
     {
         $message = (new ApnMessage)->collapseId('collapseId');
 
@@ -197,8 +179,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('collapseId', $notification->getCollapseId());
     }
 
-    /** @test */
-    public function it_adapts_apns_id()
+    public function test_it_adapts_apns_id()
     {
         $message = (new ApnMessage)->apnsId('123e4567-e89b-12d3-a456-4266554400a0');
 
@@ -207,8 +188,7 @@ class ApnAdapterTest extends TestCase
         $this->assertEquals('123e4567-e89b-12d3-a456-4266554400a0', $notification->getId());
     }
 
-    /** @test */
-    public function it_adapts_background_without_alert(): void
+    public function test_it_adapts_background_without_alert(): void
     {
         $message = (new ApnMessage)->pushType('background');
 

--- a/tests/ApnChannelTest.php
+++ b/tests/ApnChannelTest.php
@@ -26,8 +26,7 @@ class ApnChannelTest extends TestCase
         $this->channel = new ApnChannel($this->factory, $this->events);
     }
 
-    /** @test */
-    public function it_can_send_a_notification()
+    public function test_it_can_send_a_notification()
     {
         $this->client->shouldReceive('addNotification');
         $this->client->shouldReceive('push')->once();
@@ -35,8 +34,7 @@ class ApnChannelTest extends TestCase
         $this->channel->send(new TestNotifiable, new TestNotification);
     }
 
-    /** @test */
-    public function it_can_send_a_notification_with_custom_client()
+    public function test_it_can_send_a_notification_with_custom_client()
     {
         $customClient = Mockery::mock(Client::class);
 
@@ -48,8 +46,7 @@ class ApnChannelTest extends TestCase
         $this->channel->send(new TestNotifiable, new TestNotificationWithClient($customClient));
     }
 
-    /** @test */
-    public function it_dispatches_events_for_failed_notifications()
+    public function test_it_dispatches_events_for_failed_notifications()
     {
         $this->events->shouldReceive('dispatch')
             ->once()
@@ -66,8 +63,7 @@ class ApnChannelTest extends TestCase
         $this->channel->send(new TestNotifiable, new TestNotification);
     }
 
-    /** @test */
-    public function it_dispatches_failed_notification_events_with_correct_channel()
+    public function test_it_dispatches_failed_notification_events_with_correct_channel()
     {
         $this->events->shouldReceive('dispatch')
             ->withArgs(function (NotificationFailed $notificationFailed) {

--- a/tests/ApnMessageTest.php
+++ b/tests/ApnMessageTest.php
@@ -193,6 +193,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $message->custom);
         $this->assertEquals($message, $result);
     }
+
     public function test_it_can_set_url_arg()
     {
         $message = new ApnMessage;

--- a/tests/ApnMessageTest.php
+++ b/tests/ApnMessageTest.php
@@ -10,8 +10,7 @@ use Pushok\Client;
 
 class ApnMessageTest extends TestCase
 {
-    /** @test */
-    public function it_can_be_created_statically()
+    public function test_it_can_be_created_statically()
     {
         $message = ApnMessage::create('title', 'body', ['custom' => 'data'], 1);
 
@@ -23,8 +22,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals(1, $message->badge);
     }
 
-    /** @test */
-    public function it_can_set_title()
+    public function test_it_can_set_title()
     {
         $message = new ApnMessage;
 
@@ -34,8 +32,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_subtitle()
+    public function test_it_can_set_subtitle()
     {
         $message = new ApnMessage;
 
@@ -45,8 +42,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_body()
+    public function test_it_can_set_body()
     {
         $message = new ApnMessage;
 
@@ -56,8 +52,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_badge()
+    public function test_it_can_set_badge()
     {
         $message = new ApnMessage;
 
@@ -67,8 +62,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_sound()
+    public function test_it_can_set_sound()
     {
         $message = new ApnMessage;
 
@@ -78,8 +72,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_interruption_level_as_string()
+    public function test_it_can_set_interruption_level_as_string()
     {
         $message = new ApnMessage;
 
@@ -89,8 +82,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_interruption_level_as_enum()
+    public function test_it_can_set_interruption_level_as_enum()
     {
         $message = new ApnMessage;
 
@@ -100,8 +92,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_sound_to_default()
+    public function test_it_can_set_sound_to_default()
     {
         $message = new ApnMessage;
 
@@ -111,8 +102,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_category()
+    public function test_it_can_set_category()
     {
         $message = new ApnMessage;
 
@@ -122,8 +112,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_thread_id()
+    public function test_it_can_set_thread_id()
     {
         $message = new ApnMessage;
 
@@ -133,8 +122,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_content_available()
+    public function test_it_can_set_content_available()
     {
         $message = new ApnMessage;
 
@@ -144,8 +132,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_push_type()
+    public function test_it_can_set_push_type()
     {
         $message = new ApnMessage;
 
@@ -155,8 +142,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_expires_at()
+    public function test_it_can_set_expires_at()
     {
         $message = new ApnMessage;
 
@@ -168,8 +154,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_collapse_id()
+    public function test_it_can_set_collapse_id()
     {
         $message = new ApnMessage;
 
@@ -179,8 +164,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_apns_id()
+    public function test_it_can_set_apns_id()
     {
         $message = new ApnMessage;
 
@@ -190,8 +174,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_custom_value()
+    public function test_it_can_set_custom_value()
     {
         $message = new ApnMessage;
 
@@ -201,8 +184,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_custom_values()
+    public function test_it_can_set_custom_values()
     {
         $message = new ApnMessage;
 
@@ -211,8 +193,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $message->custom);
         $this->assertEquals($message, $result);
     }
-
-    public function it_can_set_url_arg()
+    public function test_it_can_set_url_arg()
     {
         $message = new ApnMessage;
 
@@ -222,8 +203,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_url_args()
+    public function test_it_can_set_url_args()
     {
         $message = new ApnMessage;
 
@@ -233,8 +213,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_custom_alert()
+    public function test_it_can_set_custom_alert()
     {
         $message = new ApnMessage;
 
@@ -244,8 +223,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_action()
+    public function test_it_can_set_action()
     {
         $message = new ApnMessage;
 
@@ -257,8 +235,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_client()
+    public function test_it_can_set_client()
     {
         $message = new ApnMessage;
 
@@ -270,8 +247,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_mutable_content()
+    public function test_it_can_set_mutable_content()
     {
         $message = new ApnMessage;
 
@@ -281,8 +257,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_title_loc_key()
+    public function test_it_can_set_title_loc_key()
     {
         $message = new ApnMessage;
 
@@ -292,8 +267,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_title_loc_args()
+    public function test_it_can_set_title_loc_args()
     {
         $message = new ApnMessage;
 
@@ -303,8 +277,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_action_loc_key()
+    public function test_it_can_set_action_loc_key()
     {
         $message = new ApnMessage;
 
@@ -314,8 +287,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_loc_key()
+    public function test_it_can_set_loc_key()
     {
         $message = new ApnMessage;
 
@@ -325,8 +297,7 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    /** @test */
-    public function it_can_set_loc_args()
+    public function test_it_can_set_loc_args()
     {
         $message = new ApnMessage;
 

--- a/tests/ApnVoipChannelTest.php
+++ b/tests/ApnVoipChannelTest.php
@@ -29,8 +29,7 @@ class ApnVoipChannelTest extends TestCase
         $this->channel = new ApnVoipChannel($this->factory, $this->events);
     }
 
-    /** @test */
-    public function it_can_send_a_notification()
+    public function test_it_can_send_a_notification()
     {
         $this->client->shouldReceive('addNotification');
         $this->client->shouldReceive('push')->once();
@@ -38,8 +37,7 @@ class ApnVoipChannelTest extends TestCase
         $this->channel->send(new TestNotifiable, new TestNotification);
     }
 
-    /** @test */
-    public function it_can_send_a_notification_with_custom_client()
+    public function test_it_can_send_a_notification_with_custom_client()
     {
         $customClient = Mockery::mock(Client::class);
 
@@ -51,8 +49,7 @@ class ApnVoipChannelTest extends TestCase
         $this->channel->send(new TestNotifiable, new TestNotificationWithClient($customClient));
     }
 
-    /** @test */
-    public function it_dispatches_events_for_failed_notifications()
+    public function test_it_dispatches_events_for_failed_notifications()
     {
         $this->events->shouldReceive('dispatch')
             ->once()

--- a/tests/ApnVoipMessageTest.php
+++ b/tests/ApnVoipMessageTest.php
@@ -6,8 +6,7 @@ use NotificationChannels\Apn\ApnVoipMessage;
 
 class ApnVoipMessageTest extends TestCase
 {
-    /** @test */
-    public function it_defaults_push_type_to_voip()
+    public function test_it_defaults_push_type_to_voip()
     {
         $message = new ApnVoipMessage;
 

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -22,8 +22,7 @@ class ClientFactoryTest extends TestCase
         $this->factory = new ClientFactory($this->app, $this->cache);
     }
 
-    /** @test */
-    public function it_returns_an_instance_through_the_cache()
+    public function test_it_returns_an_instance_through_the_cache()
     {
         $client = Mockery::mock(Client::class);
 


### PR DESCRIPTION
As Laravel 12 approaches let's take the opportunity to drop some older dependencies.

* Drop support Laravel 9 and 10
* Drop support for PHP 8.1

This updates the PHPUnit version, migrates tests to use the `test_` prefix which replaces `@test`, and fixes the two deprecation warnings.