### PR TITLE
Support edamov/pushok v0.19 for Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.4",
-        "edamov/pushok": "^0.18",
+        "edamov/pushok": "^0.18|^0.19",
         "illuminate/cache": "^12.0|^13.0",
         "illuminate/config": "^12.0|^13.0",
         "illuminate/events": "^12.0|^13.0",


### PR DESCRIPTION
Laravel 13 directly depends on brick/math >= 0.14.2.

edamov/pushok v0.19 bumps web-token/jwt-library to v4.x, which can use brick/math ^0.14, rather than just ^0.12 in v3.x.

So pushok v0.19 support is needed for this package to fully support Laravel 13.