### PR TITLE
Make Client scoped (Octane and queue worker compatibility broken)

### DIFF
--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -29,7 +29,7 @@ class ApnServiceProvider extends ServiceProvider
                 : Token::create($options);
         });
 
-        $this->app->singleton(Client::class, function ($app) {
+        $this->app->scoped(Client::class, function ($app) {
             return new Client(
                 $app->make(AuthProviderInterface::class),
                 $app['config']['broadcasting.connections.apn.production'],


### PR DESCRIPTION
APN Tokens are only valid if the `iat` is less than one hour ago, otherwise it will start returning a 403 response: https://developer.apple.com/documentation/usernotifications/establishing-a-token-based-connection-to-apns

By making the Client a singleton, it will never refresh the token in queue workers or on Laravel Octane.

To have the framework automatically generate a new token for each job, we need mark the Client as `scoped()`.

---

We could cache the generated token for 20 minutes, like it was before. Instead of caching the whole class, however, we can cache just the token string. 

Let me know if you would like to go that route instead.