### PR TITLE
Add caching for token

### DIFF
--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace NotificationChannels\Apn;
 
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 use Pushok\AuthProvider\Certificate;
@@ -18,18 +20,24 @@ class ApnServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind(AuthProviderInterface::class, function ($app) {
+        $this->app->bind(AuthProviderInterface::class, function (Application $app) {
             $options = Arr::except(
-                $app['config']['broadcasting.connections.apn'],
+                $app->get('config')['broadcasting.connections.apn'],
                 'production',
             );
 
-            return Arr::exists($options, 'certificate_path')
-                ? Certificate::create($options)
+            if (Arr::has($options, 'certificate_path')) {
+                return Certificate::create($options);
+            }
+
+            $cache = $app->get(Repository::class);
+
+            return ($token = $cache->get(Token::class))
+                ? Token::useExisting($token, $options)
                 : Token::create($options);
         });
 
-        $this->app->singleton(Client::class, function ($app) {
+        $this->app->scoped(Client::class, function ($app) {
             return new Client(
                 $app->make(AuthProviderInterface::class),
                 $app['config']['broadcasting.connections.apn.production'],

--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -2,7 +2,8 @@
 
 namespace NotificationChannels\Apn;
 
-use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -25,7 +26,7 @@ class ApnServiceProvider extends ServiceProvider
     {
         $this->app->bind(AuthProviderInterface::class, function (Application $app) {
             $options = Arr::except(
-                $app->get('config')['broadcasting.connections.apn'],
+                $app->get(ConfigRepository::class)->get('broadcasting.connections.apn'),
                 'production',
             );
 
@@ -33,7 +34,7 @@ class ApnServiceProvider extends ServiceProvider
                 return Certificate::create($options);
             }
 
-            $cache = $app->get(Repository::class);
+            $cache = $app->get(CacheRepository::class);
 
             $jwt = $cache->get(Token::class);
             if ($jwt !== null) {
@@ -42,7 +43,7 @@ class ApnServiceProvider extends ServiceProvider
 
             return tap(
                 Token::create($options),
-                fn (Token $token) => $cache->put(Token::class, $token->get(), Carbon::now()->addMinutes(self::CACHE_MINUTES))
+                fn(Token $token) => $cache->put(Token::class, $token->get(), Carbon::now()->addMinutes(self::CACHE_MINUTES))
             );
         });
 

--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -5,6 +5,7 @@ namespace NotificationChannels\Apn;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\ServiceProvider;
 use Pushok\AuthProvider\Certificate;
 use Pushok\AuthProvider\Token;
@@ -13,6 +14,8 @@ use Pushok\Client;
 
 class ApnServiceProvider extends ServiceProvider
 {
+    private const int CACHE_MINUTES = 20;
+
     /**
      * Register any application services.
      *
@@ -32,9 +35,15 @@ class ApnServiceProvider extends ServiceProvider
 
             $cache = $app->get(Repository::class);
 
-            return ($token = $cache->get(Token::class))
-                ? Token::useExisting($token, $options)
-                : Token::create($options);
+            $jwt = $cache->get(Token::class);
+            if ($jwt !== null) {
+                return Token::useExisting($jwt, $options);
+            }
+
+            return tap(
+                Token::create($options),
+                fn (Token $token) => $cache->put(Token::class, $token->get(), Carbon::now()->addMinutes(self::CACHE_MINUTES))
+            );
         });
 
         $this->app->scoped(Client::class, function ($app) {

--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -43,7 +43,7 @@ class ApnServiceProvider extends ServiceProvider
 
             return tap(
                 Token::create($options),
-                fn(Token $token) => $cache->put(Token::class, $token->get(), Carbon::now()->addMinutes(self::CACHE_MINUTES))
+                fn (Token $token) => $cache->put(Token::class, $token->get(), Carbon::now()->addMinutes(self::CACHE_MINUTES))
             );
         });
 


### PR DESCRIPTION
This adds back caching of the JWT token, but only the string, so there shouldn't be serialization errors on Laravel 13.

Any chance of a new tag once this is merged? Thanks in advance :) 