### PR TITLE
Give token it's own binding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "require": {
         "php": "^8.4",
         "edamov/pushok": "^0.18|^0.19",
+        "illuminate/cache": "^12.0|^13.0",
         "illuminate/config": "^12.0|^13.0",
         "illuminate/events": "^12.0|^13.0",
         "illuminate/notifications": "^12.0|^13.0",

--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace NotificationChannels\Apn;
 
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
@@ -30,26 +32,32 @@ class ApnServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->bind(AuthProviderInterface::class, function (Application $app) {
-            $options = Arr::except($app['config']['broadcasting.connections.apn'], 'production');
+            $config = $app->make(ConfigRepository::class);
+
+            $options = Arr::except($config->get('broadcasting.connections.apn'), 'production');
 
             if (Arr::exists($options, 'certificate_path')) {
                 return Certificate::create($options);
             }
 
-            return $this->app->make(Token::class);
+            return $app->make(Token::class);
         });
 
         $this->app->bind(Token::class, function (Application $app) {
-            $token = $app['cache']->get(static::TOKEN_CACHE_KEY);
-            $options = Arr::except($app['config']['broadcasting.connections.apn'], 'production');
+            $cache = $app->make(CacheRepository::class);
+            $config = $app->make(ConfigRepository::class);
+
+            $token = $cache->get(static::TOKEN_CACHE_KEY);
+            $options = Arr::except($config->get('broadcasting.connections.apn'), 'production');
 
             if ($token) {
                 return Token::useExisting($token, $options);
             }
 
-            return tap(Token::create($options), function (Token $token) use ($app) {
-                $app['cache']->put(static::TOKEN_CACHE_KEY, $token->get(), now()->addMinutes(self::TOKEN_CACHE_MINUTES));
-            });
+            return tap(
+                Token::create($options),
+                fn (Token $token) => $cache->put(static::TOKEN_CACHE_KEY, $token->get(), now()->addMinutes(self::TOKEN_CACHE_MINUTES)),
+            );
         });
 
         $this->app->scoped(Client::class, function (Application $app) {

--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -41,15 +41,14 @@ class ApnServiceProvider extends ServiceProvider
 
         $this->app->bind(Token::class, function (Application $app) {
             $token = $app['cache']->get(static::TOKEN_CACHE_KEY);
+            $options = Arr::except($app['config']['broadcasting.connections.apn'], 'production');
 
             if ($token) {
-                $options = Arr::except($app['config']['broadcasting.connections.apn'], 'production');
-
                 return Token::useExisting($token, $options);
             }
 
-            return tap(Token::create(), function (Token $token) use ($app) {
-                $app['cache']->put(static::TOKEN_CACHE_KEY, $token->get(), now()->addMintues(self::TOKEN_CACHE_MINUTES));
+            return tap(Token::create($options), function (Token $token) use ($app) {
+                $app['cache']->put(static::TOKEN_CACHE_KEY, $token->get(), now()->addMinutes(self::TOKEN_CACHE_MINUTES));
             });
         });
 

--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\Apn;
 
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 use Pushok\AuthProvider\Certificate;
@@ -12,21 +13,44 @@ use Pushok\Client;
 class ApnServiceProvider extends ServiceProvider
 {
     /**
+     * The token cache key.
+     */
+    const string TOKEN_CACHE_KEY = 'apn.token';
+
+    /**
+     * The token cache length.
+     */
+    const int TOKEN_CACHE_MINUTES = 20;
+
+    /**
      * Register any application services.
      *
      * @return void
      */
     public function register()
     {
-        $this->app->bind(AuthProviderInterface::class, function ($app) {
-            $options = Arr::except(
-                $app['config']['broadcasting.connections.apn'],
-                'production',
-            );
+        $this->app->bind(AuthProviderInterface::class, function (Application $app) {
+            $options = Arr::except($app['config']['broadcasting.connections.apn'], 'production');
 
-            return Arr::exists($options, 'certificate_path')
-                ? Certificate::create($options)
-                : Token::create($options);
+            if (Arr::exists($options, 'certificate_path')) {
+                return Certificate::create();
+            }
+
+            return $this->app->make(Token::class);
+        });
+
+        $this->app->bind(Token::class, function (Application $app) {
+            $token = $app['cache']->get(static::TOKEN_CACHE_KEY);
+
+            if ($token) {
+                $options = Arr::except($app['config']['broadcasting.connections.apn'], 'production');
+
+                return Token::useExisting($token, $options);
+            }
+
+            return tap(Token::create(), function (Token $token) use ($app) {
+                $app['cache']->put(static::TOKEN_CACHE_KEY, $token->get(), now()->addMintues(self::TOKEN_CACHE_MINUTES));
+            });
         });
 
         $this->app->scoped(Client::class, function ($app) {

--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -17,7 +17,7 @@ class ApnServiceProvider extends ServiceProvider
     /**
      * The token cache key.
      */
-    const string TOKEN_CACHE_KEY = 'apn.token';
+    const string TOKEN_CACHE_KEY = 'laravel_notification_channels.apn.token';
 
     /**
      * The token cache length.

--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -53,7 +53,7 @@ class ApnServiceProvider extends ServiceProvider
             });
         });
 
-        $this->app->scoped(Client::class, function ($app) {
+        $this->app->scoped(Client::class, function (Application $app) {
             return new Client(
                 $app->make(AuthProviderInterface::class),
                 $app['config']['broadcasting.connections.apn.production'],

--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -17,12 +17,12 @@ class ApnServiceProvider extends ServiceProvider
     /**
      * The token cache key.
      */
-    const string TOKEN_CACHE_KEY = 'laravel_notification_channels.apn.token';
+    public const string TOKEN_CACHE_KEY = 'laravel_notification_channels.apn.token';
 
     /**
      * The token cache length.
      */
-    const int TOKEN_CACHE_MINUTES = 20;
+    public const int TOKEN_CACHE_MINUTES = 20;
 
     /**
      * Register any application services.

--- a/src/ApnServiceProvider.php
+++ b/src/ApnServiceProvider.php
@@ -33,7 +33,7 @@ class ApnServiceProvider extends ServiceProvider
             $options = Arr::except($app['config']['broadcasting.connections.apn'], 'production');
 
             if (Arr::exists($options, 'certificate_path')) {
-                return Certificate::create();
+                return Certificate::create($options);
             }
 
             return $this->app->make(Token::class);


### PR DESCRIPTION
Slightly different approach for token caching compared to #166.

* Move caching out of the `AuthProviderInterface` binding, instead provide binding specifically for `Token`
* Keep `$app['cache']` and `$app['config']` instead of trading them for interfaces
* Add `illuminate/cache` as a dependency