### PR TITLE
fix(ApnMessage): message custom array overwrites data

### DIFF
--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -367,13 +367,9 @@ class ApnMessage
     /**
      * Add custom data to the notification.
      */
-    public function custom(array|string $custom, mixed $value = null): self
+    public function custom(array $custom): self
     {
-        if (is_array($custom)) {
-            $this->custom = array_replace($this->custom, $custom);
-        } else {
-            $this->custom[$custom] = $value;
-        }
+        $this->custom = $custom;
 
         return $this;
     }
@@ -396,17 +392,6 @@ class ApnMessage
         $this->urlArgs = $urlArgs;
 
         return $this;
-    }
-
-    /**
-     * Add an action to the notification.
-     */
-    public function action(string $action, mixed $params = null): self
-    {
-        return $this->custom('action', [
-            'action' => $action,
-            'params' => $params,
-        ]);
     }
 
     /**

--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -370,7 +370,7 @@ class ApnMessage
     public function custom(array|string $custom, mixed $value = null): self
     {
         if (is_array($custom)) {
-            $this->custom = $custom;
+            $this->custom = array_replace($this->custom, $custom);
         } else {
             $this->custom[$custom] = $value;
         }

--- a/tests/ApnAdapterTest.php
+++ b/tests/ApnAdapterTest.php
@@ -279,7 +279,7 @@ class ApnAdapterTest extends TestCase
 
     public function test_it_adapts_custom(): void
     {
-        $message = new ApnMessage()->custom('key', 'value');
+        $message = new ApnMessage()->custom(['key' => 'value']);
 
         $notification = $this->adapter->adapt($message, 'token');
 

--- a/tests/ApnMessageTest.php
+++ b/tests/ApnMessageTest.php
@@ -180,16 +180,6 @@ class ApnMessageTest extends TestCase
         $this->assertEquals($message, $result);
     }
 
-    public function test_it_can_set_custom_value(): void
-    {
-        $message = new ApnMessage;
-
-        $result = $message->custom('foo', 'bar');
-
-        $this->assertEquals(['foo' => 'bar'], $message->custom);
-        $this->assertEquals($message, $result);
-    }
-
     public function test_it_can_set_custom_values(): void
     {
         $message = new ApnMessage;
@@ -198,15 +188,6 @@ class ApnMessageTest extends TestCase
 
         $this->assertEquals(['foo' => 'bar'], $message->custom);
         $this->assertEquals($message, $result);
-
-
-        $message->custom('foo', 'bar')
-            ->custom(['baz' => 'qux']);
-
-        $this->assertEquals(
-            ['foo' => 'bar', 'baz' => 'qux'],
-            $message->custom,
-        );
     }
 
     public function test_it_can_set_url_arg(): void
@@ -236,20 +217,6 @@ class ApnMessageTest extends TestCase
         $result = $message->customAlert('foo');
 
         $this->assertEquals('foo', $message->customAlert);
-        $this->assertEquals($message, $result);
-    }
-
-    public function test_it_can_set_action(): void
-    {
-        $message = new ApnMessage;
-
-        $result = $message->action('action', ['foo' => 'bar']);
-
-        $expected = [
-            'action' => ['action' => 'action', 'params' => ['foo' => 'bar']],
-        ];
-
-        $this->assertEquals($expected, $message->custom);
         $this->assertEquals($message, $result);
     }
 

--- a/tests/ApnMessageTest.php
+++ b/tests/ApnMessageTest.php
@@ -198,6 +198,15 @@ class ApnMessageTest extends TestCase
 
         $this->assertEquals(['foo' => 'bar'], $message->custom);
         $this->assertEquals($message, $result);
+
+
+        $message->custom('foo', 'bar')
+            ->custom(['baz' => 'qux']);
+
+        $this->assertEquals(
+            ['foo' => 'bar', 'baz' => 'qux'],
+            $message->custom,
+        );
     }
 
     public function test_it_can_set_url_arg(): void


### PR DESCRIPTION
## What I have done

  `ApnMessage::custom()` silently replaces the entire `$custom` array when passed an array argument, while the string-key form merges data:
  
   ```php          
  $message->custom('action', 'open')->custom(['deepLink' => '/home']);                                                                                                                         
  // $custom === ['deepLink' => '/home']  — 'action' is lost 
  ```
  
  This inconsistency makes chaining calls error-prone.
  
### Solution
  Replace the full-array assignment with `array_replace()` so both call styles accumulate data consistently:
  
  ```php
  // Before
  $this->custom = $custom;
  
   // After
  $this->custom = array_replace($this->custom, $custom);
  ```
  
  `array_replace()` is preferred over array_merge() because it preserves numeric keys rather than re-indexing them, which is the correct semantics for updating specific keys in an existing associative array.
  
  ### After
  ```php  
  $message->custom('action', 'open')
          ->custom(['deepLink' => '/home']);
  // $custom === ['action' => 'open', 'deepLink' => '/home']
  ```
  
  ### Test Results
<img width="691" height="217" alt="スクリーンショット 2026-05-16 15 52 38" src="https://github.com/user-attachments/assets/11c997ab-ed19-4161-b61d-caf475975253" />


### Notes
The StyleCI failure appears to be unrelated to this change.
Could a maintainer confirm whether this needs to be addressed as part of this PR?