### PR TITLE
Chore: Initialize `$badge` property with null to match other nullable properties

### DIFF
--- a/src/ApnMessage.php
+++ b/src/ApnMessage.php
@@ -26,7 +26,7 @@ class ApnMessage
     /**
      * The badge of the notification.
      */
-    public ?int $badge;
+    public ?int $badge = null;
 
     /**
      * The sound of the notification.


### PR DESCRIPTION
## Description
  
  - Add explicit `= null` default to `$badge` property declaration

### Problem
`$badge` was the only nullable property in `ApnMessage` without an explicit default value. 
In PHP 8, a typed property without a default is in an "uninitialized" state — not `null` — and accessing it before assignment throws a fatal error. 
While the constructor always assigns `$badge`, the declaration was inconsistent with every other nullable property in the class.

### what I have changed

  ```php
  // Before
   public ?int $badge;
  
 // After
   public ?int $badge = null;
```
This property $badge with $title, $body, $sound, and all other nullable properties that already declare = null.